### PR TITLE
chore!: drop support for Node.js v20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20
+          node-version: 22
       - name: Install & Build
         uses: bahmutov/npm-install@ec9e87262db2a1be2ca3ceb2d506c413a220542c # v1.10.5
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "typescript-eslint": "8.19.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^22.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Christopher Hiller <boneskull@boneskull.com>",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": "^22.3.0"
   },
   "bin": {
     "snapshot-fs": "dist/esm/cli.js"


### PR DESCRIPTION
BREAKING CHANGE: This drops support for Node.js v20.x.

Mainly just need the new Node.js test tooling
